### PR TITLE
Validate unit selections when reading from local storage

### DIFF
--- a/src/OpenSEE/Scripts/TSX/defaults.ts
+++ b/src/OpenSEE/Scripts/TSX/defaults.ts
@@ -244,7 +244,8 @@ export const defaultSettings = {
     } as OpenSee.IUnitCollection,
     TimeUnit: {
         current: 5, options: [
-            { label: "auto", short: "auto", factor: 0 },
+            { label: "seconds", short: "s", factor: 0 },
+            { label: "minutes", short: "min", factor: 0 },
             { label: "milliseconds", short: "ms", factor: 0 },
             { label: "milliseconds since record start", short: "ms since event", factor: 0 },
             { label: "cycles since record start", short: "cycles", factor: 0 },

--- a/src/OpenSEE/Scripts/TSX/store/settingSlice.tsx
+++ b/src/OpenSEE/Scripts/TSX/store/settingSlice.tsx
@@ -233,11 +233,20 @@ function GetSettings(): OpenSee.ISettingsState {
 
         // For Unit (Time and regular) only grab current Unit
         Object.keys(defaultSettings.Units).forEach((key) => {
-            state.Units[key] = { ...defaultSettings.Units[key], current: (state.Units[key] != undefined ? state.Units[key].current : defaultSettings.Units[key].current) }
+            const unitValid =
+                state.Units[key] != undefined &&
+                state.Units[key].current >= 0 &&
+                state.Units[key].current < defaultSettings.Units[key].options.length;
 
+            state.Units[key] = { ...defaultSettings.Units[key], current: unitValid ? state.Units[key].current : defaultSettings.Units[key].current };
         });
 
-        state.TimeUnit = { ...defaultSettings.TimeUnit, current: (state.TimeUnit != undefined ? state.TimeUnit.current : defaultSettings.TimeUnit.current) }
+        const timeUnitValid =
+            state.TimeUnit != undefined &&
+            state.TimeUnit.current >= 0 &&
+            state.TimeUnit.current < defaultSettings.TimeUnit.options.length;
+
+        state.TimeUnit = { ...defaultSettings.TimeUnit, current: timeUnitValid ? state.TimeUnit.current : defaultSettings.TimeUnit.current };
 
         Object.keys(defaultSettings.Colors).forEach((key) => {
             if (state.Colors[key] == undefined)


### PR DESCRIPTION
As long as the defaults are sane, this should prevent catastrophic errors due to changes in unit options.