### PR TITLE
Removing reference to the old location of openSEE.jpg

### DIFF
--- a/src/OpenSEE/OpenSee.csproj
+++ b/src/OpenSEE/OpenSee.csproj
@@ -62,7 +62,6 @@
     <None Include="Scripts\jquery-3.6.0.intellisense.js" />
     <Content Include="Images\openSEE.jpg" />
     <Content Include="Images\openSEELogo.png" />
-    <Content Include="openSEE.jpg" />
     <Content Include="Scripts\OpenSee.js" />
     <Content Include="Shared\Content\Images\ui-icons_444444_256x240.png" />
     <Content Include="Shared\Content\Images\ui-icons_555555_256x240.png" />


### PR DESCRIPTION
Whenever I moved the location of openSEE.jpg to where we store other images, I forgot to remove the reference to the old file in the .csproj causing the build to fail on a publish because of the file not being there.